### PR TITLE
Fix OnCollectiblePickedup

### DIFF
--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -20051,7 +20051,7 @@
         {
           "Type": "Simple",
           "Hook": {
-            "InjectionIndex": 84,
+            "InjectionIndex": 70,
             "ReturnBehavior": 0,
             "ArgumentBehavior": 4,
             "ArgumentString": "this, a0, l4",


### PR DESCRIPTION
The OnCollectiblePickedup call must be made before the item is given to the player